### PR TITLE
Auto install and update 'pre commit'

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,6 @@ importance.
   require confirmation. Alternately allow overwrite with confirmation if an
   existing/populated directory is found. Add a force flag to skip confirmation.
   `I think DO NOT allow this when '.' is specified as this could be disastrous`.
-- add some form of 'extra packages' command line option and config setting to
-  automatically add extra packages to the generated `pyproject.toml` file.
 - add cmd line options to specify the project name, author, etc. so the user
   doesn't have to enter them manually. `Not sure if this is needed once we add
   the CLI parameters to the config file. May be useful for automation though`.
@@ -36,8 +34,6 @@ importance.
 - add a default dockerfile? Maybe a docker-compose file as well?
 - take a look at the release-drafter GitHub action and see if worth using.
 - add the `actions/stale` action to the generated project.
-- option to install the pre-commit hooks in the generated project and autoupdate
-  to the latest version.
 - add CLI command to generate the CHANGELOG.md file from the git history, using
   `github_changelog_generator`. This would take the GitHub Key from the config
   file if wanted. Note that without the Key, the GitHub API is rate limited to
@@ -50,6 +46,8 @@ These are ideas that I may or may not implement. They are here for reference.
 
 - modify boolean settings in the config to have the values 'yes', 'no' or 'ask'?
   This will be a bit lower priority and not sure if it's worth it.
+- add some form of 'extra packages' command line option and config setting to
+  automatically add extra packages to the generated `pyproject.toml` file.
 
 ## Code Quality
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,8 +14,9 @@ author_email = "user@server.com"
 author_name = "Python User"
 default_license = "MIT"
 include_linters = true
-include_mkdocs = false
+include_mkdocs = true
 include_testing = true
+install_pre_commit = true
 schema_version = "1.0" # for internal use, generally don't change this
 template_folder = "/home/user/.pymaker/template"
 use_default_template = true
@@ -26,6 +27,26 @@ If this file does not exist, it will be created on first run. The app will ask
 for the values of `author_name`, `author_email` and `default_license`. For
 `author_name` and `author_email` it will try to use the current git user name
 and email if they are set as defaults, though the user can override these.
+
+## Configuration options
+
+The following options are available for configuring Py-Maker:
+
+- `author_email`: The email address of the author.
+- `author_name`: The name of the author.
+- `default_license`: The default license to use for the project.
+- `include_linters`: Whether to include linters in the project.
+- `include_mkdocs`: Whether to include MkDocs in the project.
+- `include_testing`: Whether to include testing in the project.
+- `install_pre_commit`: Whether to install pre-commit hooks.
+- `schema_version`: The version of the configuration schema.
+- `template_folder`: The path to the template folder.
+- `use_default_template`: Whether to use the default template.
+- `use_git`: Whether to use Git for version control.
+
+All of the boolean options are set to `true` by default. The `template_folder`
+is set to the default template folder, which is `~/.pymaker/template`. The
+`schema_version` is for internal use, and should not be changed by the user.
 
 ## View configuration
 
@@ -46,3 +67,10 @@ $ pymaker config change
 
 The latter command will prompt you for the values of Author name, email and
 default License, and then update the configuration file.
+
+## Manually editing the configuration file
+
+The configuration file is stored in TOML format, and can be edited manually if
+you wish. The file is stored in `~/.pymaker/config.toml` by default. The
+configuration file is created on first run, so if you have not run the app yet,
+you will need to create the file manually.

--- a/py_maker/config/settings.py
+++ b/py_maker/config/settings.py
@@ -41,6 +41,7 @@ class Settings:
     include_mkdocs: bool = True
     include_testing: bool = True
     include_linters: bool = True
+    install_pre_commit: bool = True
 
     # cant use Pathlike here as it breaks rtoml
     template_folder: str = str(settings_folder / "template")

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -377,6 +377,7 @@ See the [bold][green]README.md[/green][/bold] file for more information.
         if (
             self.poetry_is_run
             and self.git_is_run
+            and self.settings.install_pre_commit
             and (
                 self.options["accept_defaults"]
                 or Confirm.ask(
@@ -388,14 +389,14 @@ See the [bold][green]README.md[/green][/bold] file for more information.
         ):
             print("\n--> Install and Update pre-commit hooks")
             os.chdir(self.choices.project_dir)
-            subprocess.run(
+            subprocess.run(  # nosec
                 ["poetry", "run", "pre-commit", "install"],
                 check=True,
-            )  # nosec
-            subprocess.run(
+            )
+            subprocess.run(  # nosec
                 ["poetry", "run", "pre-commit", "autoupdate"],
                 check=True,
-            )  # nosec
+            )
         else:
             print(
                 """\n  [red]Warning: pre-commit hooks not installed or updated.

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -363,5 +363,17 @@ See the [bold][green]README.md[/green][/bold] file for more information.
                     MKDOCS_CONFIG.format(name=self.choices.name)
                 )
 
+            if Confirm.ask(
+                "\nDo you want to install and update the [bold]"
+                "pre-commit[/bold] hooks?",
+                default=True,
+            ):
+                subprocess.run(
+                    ["poetry", "run", "pre-commit", "install"], check=True
+                )  # nosec
+                subprocess.run(
+                    ["poetry", "run", "pre-commit", "autoupdate"], check=True
+                )  # nosec
+
         self.create_git_repo()
         self.post_process()

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -45,6 +45,7 @@ class PyMaker:
         # this will be updated if we run 'poetry install' later, so other stages
         # that need to know if poetry has been run can check this flag.
         self.poetry_is_run = False
+        self.git_is_run = False
 
         header()
 
@@ -198,6 +199,7 @@ class PyMaker:
             repo.index.add(repo.untracked_files)
             repo.index.commit("Initial Commit")
             print("[green]Done[/green]")
+            self.git_is_run = True
         except GitError as exc:
             print("Error: ", exc)
             sys.exit(ExitErrors.GIT_ERROR)
@@ -370,12 +372,18 @@ See the [bold][green]README.md[/green][/bold] file for more information.
 
         self.create_git_repo()
 
-        if self.poetry_is_run and (
-            self.options["accept_defaults"]
-            or Confirm.ask(
-                "\nDo you want to install and update the [bold]"
-                "pre-commit[/bold] hooks?",
-                default=True,
+        # install and update pre-commit hooks IF poetry and git are run.
+        # this would fail without either of them.
+        if (
+            self.poetry_is_run
+            and self.git_is_run
+            and (
+                self.options["accept_defaults"]
+                or Confirm.ask(
+                    "\nDo you want to install and update the [bold]"
+                    "pre-commit[/bold] hooks?",
+                    default=True,
+                )
             )
         ):
             print("\n--> Install and Update pre-commit hooks")
@@ -388,5 +396,22 @@ See the [bold][green]README.md[/green][/bold] file for more information.
                 ["poetry", "run", "pre-commit", "autoupdate"],
                 check=True,
             )  # nosec
+        else:
+            print(
+                """\n  [red]Warning: pre-commit hooks not installed or updated.
+
+[/red]  pre-commit needs both 'poetry install' and 'git init' to be run.
+  Once this is done, you can install and update the pre-commit hooks later by
+  running:
+
+  [bold]$ poetry run pre-commit install[/bold]
+
+  and
+
+  [bold]$ poetry run pre-commit autoupdate[/bold]
+
+  Note that this is totally [bold]optional, but recommended.
+                """
+            )
 
         self.post_process()


### PR DESCRIPTION
This will run both `pre-commit install` and `pre-commit autoupdate` (to get the latest version of the tools) during the generation process if the user requests.

It is dependent on:

1. `poetry install` already being run
2. `git init` already being run

If the above have not been done, a message is output to that effect with instructions for manually performing this.