### PR TITLE
Remove dependency spam from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@
 - add code of conduct to project and the template [\#87](https://github.com/seapagan/py-maker/pull/87) ([seapagan](https://github.com/seapagan))
 - Add Github templates to the default output template [\#86](https://github.com/seapagan/py-maker/pull/86) ([seapagan](https://github.com/seapagan))
 
-**Merged pull requests:**
-
-- build\(deps\): bump actions/stale from 5 to 8 [\#89](https://github.com/seapagan/py-maker/pull/89) ([dependabot[bot]](https://github.com/apps/dependabot))
-
 ## [v0.5.1](https://github.com/seapagan/py-maker/tree/v0.5.1) (2023-09-12)
 
 [Full Changelog](https://github.com/seapagan/py-maker/compare/v0.5.0...v0.5.1)
@@ -28,26 +24,8 @@
 
 **Merged pull requests:**
 
-- Bump faker from 19.6.0 to 19.6.1 [\#85](https://github.com/seapagan/py-maker/pull/85) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump gitpython from 3.1.35 to 3.1.36 [\#84](https://github.com/seapagan/py-maker/pull/84) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs-material from 9.2.8 to 9.3.1 [\#83](https://github.com/seapagan/py-maker/pull/83) ([dependabot[bot]](https://github.com/apps/dependabot))
 - \[pre-commit.ci\] pre-commit autoupdate [\#81](https://github.com/seapagan/py-maker/pull/81) ([pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci))
-- Bump pymarkdownlnt from 0.9.13.3 to 0.9.13.4 [\#80](https://github.com/seapagan/py-maker/pull/80) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump faker from 19.3.1 to 19.6.0 [\#79](https://github.com/seapagan/py-maker/pull/79) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump black from 23.7.0 to 23.9.1 [\#78](https://github.com/seapagan/py-maker/pull/78) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pytest from 7.4.0 to 7.4.2 [\#77](https://github.com/seapagan/py-maker/pull/77) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump gitpython from 3.1.33 to 3.1.35 [\#76](https://github.com/seapagan/py-maker/pull/76) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pymarkdownlnt from 0.9.13 to 0.9.13.3 [\#74](https://github.com/seapagan/py-maker/pull/74) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs-material from 9.2.7 to 9.2.8 [\#73](https://github.com/seapagan/py-maker/pull/73) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocstrings from 0.22.0 to 0.23.0 [\#72](https://github.com/seapagan/py-maker/pull/72) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump actions/checkout from 3 to 4 [\#70](https://github.com/seapagan/py-maker/pull/70) ([dependabot[bot]](https://github.com/apps/dependabot))
 - \[pre-commit.ci\] pre-commit autoupdate [\#69](https://github.com/seapagan/py-maker/pull/69) ([pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci))
-- Bump mkdocs-material from 9.2.6 to 9.2.7 [\#68](https://github.com/seapagan/py-maker/pull/68) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pymarkdownlnt from 0.9.12 to 0.9.13 [\#67](https://github.com/seapagan/py-maker/pull/67) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pre-commit from 3.3.3 to 3.4.0 [\#66](https://github.com/seapagan/py-maker/pull/66) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump poethepoet from 0.22.0 to 0.22.1 [\#65](https://github.com/seapagan/py-maker/pull/65) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pymdown-extensions from 10.2.1 to 10.3 [\#64](https://github.com/seapagan/py-maker/pull/64) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump gitpython from 3.1.32 to 3.1.33 [\#62](https://github.com/seapagan/py-maker/pull/62) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.5.0](https://github.com/seapagan/py-maker/tree/v0.5.0) (2023-08-31)
 
@@ -64,19 +42,9 @@
 
 - fix unable to create standalone app [\#60](https://github.com/seapagan/py-maker/pull/60) ([seapagan](https://github.com/seapagan))
 
-**Documentation updates:**
+**Documentation:**
 
 - Update docs for latest additions [\#59](https://github.com/seapagan/py-maker/pull/59) ([seapagan](https://github.com/seapagan))
-
-**Merged pull requests:**
-
-- Bump mkdocs-material from 9.2.3 to 9.2.6 [\#57](https://github.com/seapagan/py-maker/pull/57) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pymdown-extensions from 10.1 to 10.2.1 [\#56](https://github.com/seapagan/py-maker/pull/56) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pymdown-extensions from 10.1 to 10.2 [\#54](https://github.com/seapagan/py-maker/pull/54) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs-material from 9.2.3 to 9.2.5 [\#53](https://github.com/seapagan/py-maker/pull/53) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pydantic from 2.1.1 to 2.3.0 [\#52](https://github.com/seapagan/py-maker/pull/52) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump faker from 19.3.0 to 19.3.1 [\#51](https://github.com/seapagan/py-maker/pull/51) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs-material from 9.1.21 to 9.2.3 [\#50](https://github.com/seapagan/py-maker/pull/50) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.4.5](https://github.com/seapagan/py-maker/tree/v0.4.5) (2023-08-17)
 
@@ -86,11 +54,6 @@
 
 - work on the TODO list. See commits for details [\#44](https://github.com/seapagan/py-maker/pull/44) ([seapagan](https://github.com/seapagan))
 
-**Merged pull requests:**
-
-- Bump mypy from 1.5.0 to 1.5.1 [\#45](https://github.com/seapagan/py-maker/pull/45) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pytest-randomly from 3.14.0 to 3.15.0 [\#43](https://github.com/seapagan/py-maker/pull/43) ([dependabot[bot]](https://github.com/apps/dependabot))
-
 ## [v0.4.4](https://github.com/seapagan/py-maker/tree/v0.4.4) (2023-08-15)
 
 [Full Changelog](https://github.com/seapagan/py-maker/compare/v0.4.3...v0.4.4)
@@ -99,11 +62,6 @@
 
 - add mkdocs as an option [\#42](https://github.com/seapagan/py-maker/pull/42) ([seapagan](https://github.com/seapagan))
 
-**Merged pull requests:**
-
-- Bump poethepoet from 0.21.1 to 0.22.0 [\#41](https://github.com/seapagan/py-maker/pull/41) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pytest-randomly from 3.13.0 to 3.14.0 [\#40](https://github.com/seapagan/py-maker/pull/40) ([dependabot[bot]](https://github.com/apps/dependabot))
-
 ## [v0.4.3](https://github.com/seapagan/py-maker/tree/v0.4.3) (2023-08-13)
 
 [Full Changelog](https://github.com/seapagan/py-maker/compare/v0.4.2...v0.4.3)
@@ -111,10 +69,6 @@
 **Implemented enhancements:**
 
 - Tweak linting [\#39](https://github.com/seapagan/py-maker/pull/39) ([seapagan](https://github.com/seapagan))
-
-**Merged pull requests:**
-
-- Bump mypy from 1.4.1 to 1.5.0 [\#38](https://github.com/seapagan/py-maker/pull/38) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.4.2](https://github.com/seapagan/py-maker/tree/v0.4.2) (2023-08-10)
 
@@ -132,14 +86,6 @@
 
 - Implement custom template additions [\#31](https://github.com/seapagan/py-maker/pull/31) ([seapagan](https://github.com/seapagan))
 
-**Merged pull requests:**
-
-- Bump faker from 19.2.0 to 19.3.0 [\#37](https://github.com/seapagan/py-maker/pull/37) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pygments from 2.15.1 to 2.16.1 [\#36](https://github.com/seapagan/py-maker/pull/36) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs from 1.5.1 to 1.5.2 [\#35](https://github.com/seapagan/py-maker/pull/35) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump rich from 13.5.0 to 13.5.2 [\#34](https://github.com/seapagan/py-maker/pull/34) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs-minify-plugin from 0.7.0 to 0.7.1 [\#33](https://github.com/seapagan/py-maker/pull/33) ([dependabot[bot]](https://github.com/apps/dependabot))
-
 ## [v0.3.0](https://github.com/seapagan/py-maker/tree/v0.3.0) (2023-07-30)
 
 [Full Changelog](https://github.com/seapagan/py-maker/compare/v0.2.1...v0.3.0)
@@ -148,13 +94,6 @@
 
 - Add a configuration file  [\#30](https://github.com/seapagan/py-maker/pull/30) ([seapagan](https://github.com/seapagan))
 - use conditional logic in templates [\#24](https://github.com/seapagan/py-maker/pull/24) ([seapagan](https://github.com/seapagan))
-
-**Merged pull requests:**
-
-- Bump mkdocs-material from 9.1.19 to 9.1.21 [\#29](https://github.com/seapagan/py-maker/pull/29) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mkdocs from 1.4.3 to 1.5.1 [\#28](https://github.com/seapagan/py-maker/pull/28) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pylint from 2.17.4 to 2.17.5 [\#26](https://github.com/seapagan/py-maker/pull/26) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pydantic from 2.0.3 to 2.1.1 [\#22](https://github.com/seapagan/py-maker/pull/22) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.2.1](https://github.com/seapagan/py-maker/tree/v0.2.1) (2023-07-26)
 
@@ -172,16 +111,6 @@
 
 - Move licenses out of template folder [\#21](https://github.com/seapagan/py-maker/pull/21) ([seapagan](https://github.com/seapagan))
 - subclass the Rich prompt locally [\#20](https://github.com/seapagan/py-maker/pull/20) ([seapagan](https://github.com/seapagan))
-- Bump pytest-asyncio from 0.21.0 to 0.21.1 [\#19](https://github.com/seapagan/py-maker/pull/19) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump flake8-type-checking from 2.4.0 to 2.4.1 [\#18](https://github.com/seapagan/py-maker/pull/18) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump gitpython from 3.1.31 to 3.1.32 [\#17](https://github.com/seapagan/py-maker/pull/17) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pydantic from 2.0.2 to 2.0.3 [\#16](https://github.com/seapagan/py-maker/pull/16) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump mock from 5.0.2 to 5.1.0 [\#15](https://github.com/seapagan/py-maker/pull/15) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump faker from 18.11.2 to 19.2.0 [\#14](https://github.com/seapagan/py-maker/pull/14) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump poethepoet from 0.20.0 to 0.21.1 [\#12](https://github.com/seapagan/py-maker/pull/12) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pytest-reverse from 1.6.0 to 1.7.0 [\#10](https://github.com/seapagan/py-maker/pull/10) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump black from 23.3.0 to 23.7.0 [\#9](https://github.com/seapagan/py-maker/pull/9) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump pytest-randomly from 3.12.0 to 3.13.0 [\#8](https://github.com/seapagan/py-maker/pull/8) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.1.0](https://github.com/seapagan/py-maker/tree/v0.1.0) (2023-07-06)
 
@@ -193,7 +122,6 @@
 
 **Merged pull requests:**
 
-- Bump pydantic from 2.0 to 2.0.2 [\#4](https://github.com/seapagan/py-maker/pull/4) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Refactor the src template layout and logic [\#2](https://github.com/seapagan/py-maker/pull/2) ([seapagan](https://github.com/seapagan))
 - Add base app functionality [\#1](https://github.com/seapagan/py-maker/pull/1) ([seapagan](https://github.com/seapagan))
 


### PR DESCRIPTION
Dependabot makes a lot of PRs which in turn causes a lot of spam in the generated CHANGELOG.md. This PR removes any PR with the tag 'dependencies' from the output.

I use [Github Changelog Generator](https://github.com/github-changelog-generator/github-changelog-generator) locally to generate the CHANGELOG.md - this is a `Ruby` application since I have not yet managed to find a comparable Python one.

This is a local change to the config file `.github_changelog_generator` by adding the line `exclude-labels=dependencies`. 
This config file is not uploaded to the repo since it contains a GitHub key.

