### PR TITLE
adjust suggested git repo name

### DIFF
--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -319,7 +319,7 @@ See the [bold][green]README.md[/green][/bold] file for more information.
                     "Repository URL?",
                     default=(
                         "https://github.com/your_user_name/"
-                        f"{self.choices.package_name}"
+                        f"{re.sub(r'[_.]+', '-', self.choices.package_name)}"
                     ),
                 )
 


### PR DESCRIPTION
change the suggested Git repository name to be dashes instead of underscores. Default is taken from the entered/suggested project name, replacing underscores and periods by a dash 