### PR TITLE
store and use GitHub username

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,6 @@
   "python.testing.pytestArgs": ["tests"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "ruff.organizeImports": false
+  "ruff.organizeImports": false,
+  "ruff.fixAll": false
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ example of this file is:
 author_email = "user@server.com"
 author_name = "Python User"
 default_license = "MIT"
+github_username = "githubuser"
 include_linters = true
 include_mkdocs = true
 include_testing = true
@@ -35,6 +36,7 @@ The following options are available for configuring Py-Maker:
 - `author_email`: The email address of the author.
 - `author_name`: The name of the author.
 - `default_license`: The default license to use for the project.
+- `github_username`: The GitHub username of the author [optional].
 - `include_linters`: Whether to include linters in the project.
 - `include_mkdocs`: Whether to include MkDocs in the project.
 - `include_testing`: Whether to include testing in the project.

--- a/py_maker/config/settings.py
+++ b/py_maker/config/settings.py
@@ -4,7 +4,7 @@ Allows reading from a settings file and writing to it.
 """
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import rtoml
 from rich import print  # pylint: disable=redefined-builtin
@@ -35,6 +35,7 @@ class Settings:
     schema_version: str = "none"
     author_name: str = ""
     author_email: str = ""
+    github_username: Optional[str] = "<your github username>"
     default_license: str = "None"
     use_default_template: bool = True
     use_git: bool = True
@@ -118,6 +119,10 @@ class Settings:
         self.author_email = Prompt.ask(
             "Author Email?",
             default=git_email if missing else self.author_email,
+        )
+        self.github_username = Prompt.ask(
+            "Github Username? \[optional]",  # noqa W605 # type: ignore
+            default="" if missing else self.github_username,
         )
         self.default_license = Prompt.ask(
             "Application License?",

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -315,10 +315,15 @@ See the [bold][green]README.md[/green][/bold] file for more information.
             if not self.choices.standalone:
                 self.choices.homepage = Prompt.ask("Homepage URL?", default="")
 
+                github_username = (
+                    self.settings.github_username
+                    if self.settings.github_username
+                    else "<your GitHub username>"
+                )
                 self.choices.repository = Prompt.ask(
                     "Repository URL?",
                     default=(
-                        "https://github.com/your_user_name/"
+                        f"https://github.com/{github_username}/"
                         f"{re.sub(r'[_.]+', '-', self.choices.package_name)}"
                     ),
                 )


### PR DESCRIPTION
This allows us to generate better default URLs for the repository. Optional setting