### PR TITLE
add optional  github_token setting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,8 +37,11 @@ importance.
 - add CLI command to generate the CHANGELOG.md file from the git history, using
   `github_changelog_generator`. This would take the GitHub Key from the config
   file if wanted. Note that without the Key, the GitHub API is rate limited to
-  50 requests per hour which is not usualy usable unless you have a very small
+  50 requests per hour which is not usually usable unless you have a very small
   project with few commits.
+- update the POE tasks to add help text to each task.
+- automatically create the new GitHub repository from the CLI. This would
+  require the GitHub API key to be in the config file.
 
 ## Back Burner
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,34 @@ $ pymaker config change
 The latter command will prompt you for the values of Author name, email and
 default License, and then update the configuration file.
 
+## Add a GitHub Personal Access Token
+
+In future versions, this app will be able to create a new GitHub repository for
+you, and generate a CHANGELOG.md file. To do this, it will need a GitHub
+Personal Access Token. You can create a new token by going to [GitHub Personal
+Access Tokens](<https://github.com/settings/tokens>){:target="_blank"} and
+clicking on the "Generate new token" button. Use the 'Classic' token option
+unless you really need more control. Unless you want to use the token on Private
+repositories, you can leave all the permissions unchecked. Give it a name (for
+your reference only) and chose an expiry date. You can choose never to expire,
+but this is not recommended. Once you have created the token, copy it (it will
+only be shown once, so make sure you copy it now). Then run the command:
+
+```console
+$ pymaker config token
+```
+
+This will accept the token and store it in the configuration file. You can
+change the token at any time by running the same command again.
+
+!!! danger "NEVER PUSH THE CONFIG FILE TO A REPOSITORY!!!"
+
+    This shouldnt ever happen since the file is stored in the user's home
+    directory, but it is worth mentioning. If you didn't choose any extra
+    permissions, then the worst that can happen is that someone can use your token
+    to create a new repository. This token is READ-ONLY, so it can't be used to do
+    anything malicious, but it is still a good idea to keep it secret.
+
 ## Manually editing the configuration file
 
 The configuration file is stored in TOML format, and can be edited manually if

--- a/py_maker/commands/config.py
+++ b/py_maker/commands/config.py
@@ -21,3 +21,11 @@ def change() -> None:
     header()
     settings = Settings()
     settings.change_settings()
+
+
+@app.command()
+def token() -> None:
+    """Change the current configuration."""
+    header()
+    settings = Settings()
+    settings.change_token()

--- a/py_maker/config/settings.py
+++ b/py_maker/config/settings.py
@@ -146,3 +146,13 @@ class Settings:
         self.get_user_settings()
 
         self.save()
+
+    def change_token(self) -> None:
+        """Allow the user to add a GitHub PAT."""
+        print("--> [green]Enter a GitHub Personal Access Token:\n")
+        self.github_token = Prompt.ask(
+            "Github Token?",
+            default=self.github_token,
+        )
+
+        self.save()

--- a/py_maker/config/settings.py
+++ b/py_maker/config/settings.py
@@ -35,7 +35,8 @@ class Settings:
     schema_version: str = "none"
     author_name: str = ""
     author_email: str = ""
-    github_username: Optional[str] = "<your github username>"
+    github_username: Optional[str] = ""
+    github_token: Optional[str] = ""
     default_license: str = "None"
     use_default_template: bool = True
     use_git: bool = True

--- a/py_maker/helpers.py
+++ b/py_maker/helpers.py
@@ -88,7 +88,10 @@ def show_table(settings: Dict[str, str]):
     table.add_column("Value")
 
     for key, value in settings.items():
-        table.add_row(pretty_attrib(key), str(value))
+        if "token" not in key:
+            table.add_row(pretty_attrib(key), str(value))
+        else:
+            table.add_row(pretty_attrib(key), "********")
     console.print(table)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,3 +173,4 @@ omit = ["*/tests/*"]
 
 [tool.pymarkdown]
 plugins.md014.enabled = false
+plugins.md046.enabled = false


### PR DESCRIPTION
Add an optional GitHub token to the configuration. This will be used to generate the CHANGELOG and in future if we offer the option to create a GitHub repo directly