### PR TITLE
Add a POE Task to automatically create and update the CHANGELOG.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,22 @@ If you add any new features, please add tests for them. This will help us to
 ensure that the code is working as expected and will prevent any regressions.
 *Currently we are not enforcing this until we have better coverage of the code.*
 
+## Changelog
+
+The changelog is automatically generated, so please do not edit it manually.
+
+For information, it is generated using a **Ruby** gem called [GitHub Changelog
+Generator](https://github.com/github-changelog-generator/github-changelog-generator).
+There is a POE task that will run this and update the changelog file.
+
+```console
+$ poe changelog
+```
+
+**However, you should NOT include a change to the `CHANGELOG.md` file in your
+Pull Requests. This will be handled by the maintainers when a new release is
+made.**
+
 ## Guidelines
 
 Here are some guidelines to follow when contributing to Py-Maker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,11 @@ There is a POE task that will run this and update the changelog file.
 $ poe changelog
 ```
 
+you also need to add a GitHub Personal Access Token to the config file. See the
+section in the
+[Documentation](http://127.0.0.1:8000/configuration/#add-a-github-personal-access-token)
+for information.
+
 **However, you should NOT include a change to the `CHANGELOG.md` file in your
 Pull Requests. This will be handled by the maintainers when a new release is
 made.**

--- a/TODO.md
+++ b/TODO.md
@@ -34,11 +34,6 @@ importance.
 - add a default dockerfile? Maybe a docker-compose file as well?
 - take a look at the release-drafter GitHub action and see if worth using.
 - add the `actions/stale` action to the generated project.
-- add CLI command to generate the CHANGELOG.md file from the git history, using
-  `github_changelog_generator`. This would take the GitHub Key from the config
-  file if wanted. Note that without the Key, the GitHub API is rate limited to
-  50 requests per hour which is not usually usable unless you have a very small
-  project with few commits.
 - update the POE tasks to add help text to each task.
 - automatically create the new GitHub repository from the CLI. This would
   require the GitHub API key to be in the config file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ lint = ["black", "flake8", "mypy", "try", "pylint"]
 "docs:serve" = "mkdocs serve -w TODO.md -w CHANGELOG.md"
 "docs:serve:all" = "mkdocs serve -w TODO.md -w CHANGELOG.md -a 0.0.0.0:9000"
 
+# this needs the Ruby utility below installed.
+changelog = "github_changelog_generator -u seapagan -p py-maker"
+
 # configure assorted tools and linters
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This currently uses the **Ruby** program [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator) which needs to be installed independently. 

I am planning to rewrite this myself in Python shortly which will offer better integration options.