### PR TITLE
Add '--standalone' CLI flag

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,9 +15,6 @@ importance.
 - add cmd line options to specify the project name, author, etc. so the user
   doesn't have to enter them manually. `Not sure if this is needed once we add
   the CLI parameters to the config file. May be useful for automation though`.
-- add a command line option to specify the project type so the user doesn't have
-  to enter it manually. ie `--standalone` or `--package`(latter is default and
-  wouldn't need to be specified).
 - add a command to the CLI template command to show the template files as a
   tree, marking whether each file/folder is from the internal templates or the
   user's templates.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,7 +39,8 @@ When it asks "Package Name?" you can choose two variants :
 2. **For a stand-alone tool** that will not be uploaded to PyPI, or is not a
    library, enter '-' for the package name. In this case the `main.py` will just
    be placed in the project root and no package folder will be created or
-   referenced.
+   referenced. You can also specify `--standalone` on the command line to skip
+    this question.
 
 For option 1 above, the App will check if the package name is available on PyPI
 or if it has already been used. In the latter case, you will be asked to choose
@@ -83,6 +84,13 @@ passed on the command line.
 If you choose to run `poetry` automatically, this will also add a customized
 `mkdocs.yml` file and create a new default MkDocs site in the `docs` folder.
 Some useful plugins are also installed and added to the `mkdocs.yml` file.
+
+### `--standalone`
+
+Generate a stand-alone script instead of a package. This will place the
+`main.py` file in the project root and not create a package folder. This is
+useful for creating a single script that can be run from the command line.
+this is equivalent to entering `-` for the package name.
 
 ## Run `poetry install` automatically
 

--- a/py_maker/commands/new.py
+++ b/py_maker/commands/new.py
@@ -39,6 +39,15 @@ def new(
         Optional[bool],
         typer.Option(help="Add the MkDocs boilerplate.", show_default=False),
     ] = None,
+    standalone: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--standalone",
+            "-s",
+            help="Create a standalone project, not a package.",
+            show_default=False,
+        ),
+    ] = False,
 ) -> None:
     """Create a new Python project."""
     options = {
@@ -47,6 +56,7 @@ def new(
         "lint": settings.include_linters if lint is None else lint,
         "docs": settings.include_mkdocs if docs is None else docs,
         "accept_defaults": accept_defaults,
+        "standalone": standalone,
     }
 
     if " " in location:


### PR DESCRIPTION
Add a flag (`--standalone`) to the `new` command, bypassing creating a package. This is equivalent to typing '`-`' as the package name.

There is no complementary flag for creating a package since that is the default. Also, at this time, I have no plans to add this as a configuration option.