### PR TITLE
add '--bare' option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,6 +92,13 @@ Generate a stand-alone script instead of a package. This will place the
 useful for creating a single script that can be run from the command line.
 this is equivalent to entering `-` for the package name.
 
+### `--bare`
+
+Generate a project **without** Testing, linting or documentation libraries and
+configurations. It will also **NOT** initialise a Git repository. Currently
+there is no config file option to do this automatically, you must use the
+command line option.
+
 ## Run `poetry install` automatically
 
 You will be asked if you want to run `poetry install` automatically. This will

--- a/py_maker/commands/new.py
+++ b/py_maker/commands/new.py
@@ -48,6 +48,18 @@ def new(
             show_default=False,
         ),
     ] = False,
+    bare: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--bare",
+            "-b",
+            help=(
+                "Create a basic project, without any testing, "
+                "docs, linting or Git repository."
+            ),
+            show_default=False,
+        ),
+    ] = False,
 ) -> None:
     """Create a new Python project."""
     options: Dict[str, Union[bool, None]] = {
@@ -57,6 +69,7 @@ def new(
         "docs": settings.include_mkdocs if docs is None else docs,
         "accept_defaults": accept_defaults,
         "standalone": standalone,
+        "bare": bare,
     }
 
     if " " in location:

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -448,6 +448,12 @@ See the [bold][green]README.md[/green][/bold] file for more information.
         else:
             self.get_input()
 
+        if self.options["bare"]:
+            self.options["test"] = False
+            self.options["lint"] = False
+            self.options["docs"] = False
+            self.options["git"] = False
+
         self.create_folders()
         self.generate_template()
 


### PR DESCRIPTION
Add the option to create a 'bare' project  - this will not add testing, linting, and docs, nor will it initialize a git repository.