### PR TITLE
Add help to poe tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,8 @@ importance.
 - Perhaps add AUTHORS.md skeleton.
 - Add template GitHub workflows for CI/CD, testing, etc. CodeQL or is that too
   much (I do use it in most of my repos)?
-- Add a default dockerfile? Maybe a docker-compose file as well?
+- Add a default dockerfile? Maybe a docker-compose file as well- Both for this
+  project and for the generated projects?
 - Add the `actions/stale` action to the generated project.
 - Update the POE tasks to add help text to each task.
 - Automatically create the new GitHub repository from the CLI. This would

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,27 +104,41 @@ types-requests = "^2.31.0.2"
 # setup 'PoeThePoet' tasks
 [tool.poe.tasks]
 pre.cmd = "pre-commit run --all-files"
+pre.help = "Run pre-commit checks"
 pylint.cmd = "pylint **/*.py"
+pylint.help = "Run pylint checks"
 mypy.cmd = "mypy **/*.py"
+mypy.help = "Run mypy checks"
 flake8.cmd = "flake8 **/*.py"
+flake8.help = "Run flake8 checks"
 black.cmd = "black **/*.py"
+black.help = "Check and format code with black"
 try.cmd = "tryceratops **/*.py"
+try.help = "Run tryceratops checks"
 markdown.cmd = "pymarkdown scan **/*.md"
+markdown.help = "Run markdown checks"
 lint.sequence = ["black", "flake8", "mypy", "try", "pylint"]
+lint.help = "Run all linting checks"
 
 # special MyPy task to check for missing type annotations
 # we don't want to enforce full typing yet on the 'mypy' task, but still do want
 # to check for missing annotations at intervals.
 "mypy:strict".cmd = "mypy --strict  **/*.py"
+"mypy:strict".help = "Run mypy checks with strict type checking"
 
 # tasks to deal with documentation
 "docs:publish".cmd = "mkdocs gh-deploy"
+"docs:publish".help = "Publish documentation to GitHub Pages"
 "docs:build".cmd = "mkdocs build"
+"docs:build".help = "Build documentation locally to './site' folder"
 "docs:serve".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md"
+"docs:serve".help = "Serve documentation locally"
 "docs:serve:all".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -a 0.0.0.0:9000"
+"docs:serve:all".help = "Serve documentation locally on all interfaces"
 
 # Generate a CHANGELOG.md - this needs the Ruby utility below installed.
 changelog.cmd = "github_changelog_generator -u seapagan -p py-maker"
+changelog.help = "Generate a CHANGELOG.md file"
 
 # configure assorted tools and linters
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,29 +101,30 @@ pygments = "^2.15.1"
 # typing stubs
 types-requests = "^2.31.0.2"
 
+# setup 'PoeThePoet' tasks
 [tool.poe.tasks]
-# setup PoeThePoet tasks
-pre = "pre-commit run --all-files"
-pylint = "pylint **/*.py"
-mypy = "mypy **/*.py"
-flake8 = "flake8 **/*.py"
-black = "black **/*.py"
-try = "tryceratops **/*.py"
-markdown = "pymarkdown scan **/*.md"
-lint = ["black", "flake8", "mypy", "try", "pylint"]
+pre.cmd = "pre-commit run --all-files"
+pylint.cmd = "pylint **/*.py"
+mypy.cmd = "mypy **/*.py"
+flake8.cmd = "flake8 **/*.py"
+black.cmd = "black **/*.py"
+try.cmd = "tryceratops **/*.py"
+markdown.cmd = "pymarkdown scan **/*.md"
+lint.sequence = ["black", "flake8", "mypy", "try", "pylint"]
 
 # special MyPy task to check for missing type annotations
 # we don't want to enforce full typing yet on the 'mypy' task, but still do want
 # to check for missing annotations at intervals.
-typing = "mypy --strict  **/*.py"
+"mypy:strict".cmd = "mypy --strict  **/*.py"
 
-"docs:publish" = "mkdocs gh-deploy"
-"docs:build" = "mkdocs build"
-"docs:serve" = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md"
-"docs:serve:all" = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -a 0.0.0.0:9000"
+# tasks to deal with documentation
+"docs:publish".cmd = "mkdocs gh-deploy"
+"docs:build".cmd = "mkdocs build"
+"docs:serve".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md"
+"docs:serve:all".cmd = "mkdocs serve -w TODO.md -w CHANGELOG.md -w CONTRIBUTING.md -a 0.0.0.0:9000"
 
-# this needs the Ruby utility below installed.
-changelog = "github_changelog_generator -u seapagan -p py-maker"
+# Generate a CHANGELOG.md - this needs the Ruby utility below installed.
+changelog.cmd = "github_changelog_generator -u seapagan -p py-maker"
 
 # configure assorted tools and linters
 [tool.isort]


### PR DESCRIPTION
Add help text to the list of POE tasks. This list can be shown by typing 'poe' at the command line