### PR TITLE
Automatically create a GitHub repository for the new project

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,17 +50,22 @@ These are ideas that I may or may not implement. They are here for reference.
   much (I do use it in most of my repos)?
 - Add the `actions/stale` action to the generated project.
 
-## Code Quality
+## Refactoring / Code Cleanup
 
 - Refactor the `PyMaker` class as its getting a bit messy. Maybe split it into
   multiple classes with specific responsibilities.
 - Sort out the nested `if/else` statements in
   `PyMaker.get_sanitized_package_name`.
+- split the file copy and template handling functionality into it's own module
+  and have the `PyMaker` class use it.
+- split the `ExitErrors` class into an 'errors' module, add more error types if
+  needed and use them throughout the code.
 
 ## Documentation
 
 - Add usage examples and perhaps a walk-through to the documentation. Maybe
   with a YouTube video?
+- explain how to add more License templates to the 'licenses' module
 
 ## Testing
 


### PR DESCRIPTION
Offer the option to create a GitHub repository for the new project automatically. This needs the GitHub PAT to be specified in the config plus the correct username and will abort if not.

- [ ] Implement base functionality, create Repo if requested
- [ ] Add config settings to enable/disable
- [ ] Add command line options to overrule `--github` and `--no-github`
- [ ] Check for any existing repo with this name on the users account
- [ ] Add to the `--yes` flag to do without asking
- [ ] Ask for missing GitHub  username and PAT, store in config if supplied