### PR TITLE
Fix several issues with generating standalone projects

### DIFF
--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -319,11 +319,16 @@ See the [bold][green]README.md[/green][/bold] file for more information.
                 if self.settings.github_username
                 else "<your GitHub username>"
             )
+            repo_name = (
+                sanitize(self.choices.project_dir.name)
+                if self.choices.package_name == "-"
+                else self.choices.package_name
+            )
             self.choices.repository = Prompt.ask(
                 "Repository URL?",
                 default=(
                     f"https://github.com/{github_username}/"
-                    f"{re.sub(r'[_.]+', '-', self.choices.package_name)}"
+                    f"{re.sub(r'[_.]+', '-', repo_name.lower())}"
                 ),
             )
 

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -221,6 +221,12 @@ class PyMaker:
         proj_loc = (
             self.location if self.location != "." else self.choices.project_dir
         )
+        run_cmd = (
+            f"{self.location}"
+            if not self.choices.standalone
+            else "python main.py"
+        )
+
         output = f"""
 --> [green]Project created successfully.[/green]
 
@@ -233,7 +239,7 @@ class PyMaker:
     3) Activate the virtual environment:
         'poetry shell'
     4) Run the application:
-        '{self.location}'
+        '{run_cmd}'
     5) Code!
 
 See the [bold][green]README.md[/green][/bold] file for more information.

--- a/py_maker/template/pyproject.toml.jinja
+++ b/py_maker/template/pyproject.toml.jinja
@@ -23,6 +23,10 @@ repository = "{{ repository }}"
 # rename "{{ slug }}" below to change the executable name. You can also
 # add more scripts if your package offers multiple commands.
 {{ slug }} = "{{ package_name }}.main:app"
+
+{% else%}
+package-mode = false
+
 {% endif %}
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Closes the following issues:

- ensure `package-mode=false` is set for standalone  scripts (closes #292)
- change the post-process text to reflect whether the project is standalone or not (closes #293)
- fix the bad repo suggestion for standalone projects (closes #296)