### PR TITLE
Convert settings fie to use new `get_settings()` method

### DIFF
--- a/py_maker/commands/config.py
+++ b/py_maker/commands/config.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from py_maker.config import settings
+from py_maker.config import get_settings
 from py_maker.helpers import header, show_table
 
 app = typer.Typer(no_args_is_help=True)
@@ -12,25 +12,25 @@ app = typer.Typer(no_args_is_help=True)
 def show() -> None:
     """Show the current settings from the Configuration file."""
     header()
-    show_table(settings.get_attrs())
+    show_table(get_settings().get_attrs())
 
 
 @app.command()
 def change() -> None:
     """Change the current configuration."""
     header()
-    settings.change_settings()
+    get_settings().change_settings()
 
 
 @app.command()
 def token() -> None:
     """Change the current token."""
     header()
-    settings.change_token()
+    get_settings().change_token()
 
 
 @app.command(name="edit")
 def edit_config() -> None:
     """Open the Configuration file in the default editor."""
     header()
-    settings.edit_config()
+    get_settings().edit_config()

--- a/py_maker/commands/new.py
+++ b/py_maker/commands/new.py
@@ -5,7 +5,7 @@ from typing import Annotated, Optional, Union
 import typer
 from rich import print  # pylint: disable=W0622
 
-from py_maker.config import settings
+from py_maker.config import get_settings
 from py_maker.constants import ExitErrors
 from py_maker.pymaker import PyMaker
 
@@ -70,6 +70,8 @@ def new(
     ] = None,
 ) -> None:
     """Create a new Python project."""
+    settings = get_settings()
+
     options: dict[str, Union[bool, None]] = {
         "git": settings.use_git if git is None else git,
         "test": settings.include_testing if test is None else test,

--- a/py_maker/commands/template.py
+++ b/py_maker/commands/template.py
@@ -8,7 +8,7 @@ import typer
 from rich import print  # pylint: disable=redefined-builtin
 
 from py_maker import template
-from py_maker.config import settings
+from py_maker.config import get_settings
 from py_maker.constants import ExitErrors
 from py_maker.helpers import get_file_list, header
 from py_maker.prompt import Confirm
@@ -41,6 +41,7 @@ def dump(
     """
     header()
     template_source: Traversable = pkg_resources.files(template)
+    settings = get_settings()
 
     try:
         if not local:
@@ -102,6 +103,7 @@ def default(action: str) -> None:
     [b]enable[/b] will enable the internal template
     [b]disable[/b] will disable the internal template folder
     """
+    settings = get_settings()
     header()
     if action == "enable":
         settings.use_default_template = True
@@ -128,6 +130,7 @@ def set_template() -> None:
 
     The [i]'Use Default Template'[/i] setting [b][red]will not be changed[/b].
     """
+    settings = get_settings()
     header()
     if not Confirm.ask(
         "[red]Are you sure you want to set the template folder to the "
@@ -157,6 +160,7 @@ def reset_template() -> None:
     This is currrently [b]~/.pymaker/template[/b].
     The [i]'Use Default Template'[/i] setting [b][red]will not be changed[/b].
     """
+    settings = get_settings()
     header()
     if not Confirm.ask(
         "[red]Are you sure you want to reset the template folder to the "

--- a/py_maker/config/__init__.py
+++ b/py_maker/config/__init__.py
@@ -1,5 +1,13 @@
 """Settings module."""
 
-from .settings import settings
+from typing import Any
 
-__all__ = ["settings"]
+from .settings import Settings
+
+
+def get_settings(*args: Any, **kwargs: Any) -> Settings:  # noqa: ANN401
+    """Return a singleton instance of the Settings class."""
+    return Settings.get_instance("pymaker", *args, **kwargs)
+
+
+__all__ = ["Settings", "get_settings"]

--- a/py_maker/config/settings.py
+++ b/py_maker/config/settings.py
@@ -145,6 +145,3 @@ class Settings(TOMLSettings):
                     "--> [red]No editor found. Please edit the settings file "
                     "manually.\n"
                 )
-
-
-settings = Settings("pymaker")

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -17,7 +17,7 @@ from jinja2 import Environment, FileSystemLoader
 from rich import print  # pylint: disable=W0622
 
 from py_maker import template
-from py_maker.config import settings
+from py_maker.config import get_settings
 from py_maker.constants import MKDOCS_CONFIG, ExitErrors, license_names
 from py_maker.github_ctrl import GitHub
 from py_maker.helpers import (
@@ -53,7 +53,7 @@ class PyMaker:
 
         header()
 
-        self.settings = settings
+        self.settings = get_settings()
 
         if len(Path(self.location).parts) > 1:
             print(


### PR DESCRIPTION
The `get_settings()` class method is a new method in `simple-toml-settings` version 0.5.0.

It allows to get a singleton instance of the Settings class that can be used anywhere in the application without creating a new class.

This also removes the side-effect of creating a Settings instance when importing `config.settings` which should make testing a lot easier