### PR TITLE
Fix bug where bad homepage field crashes `poetry install`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,6 +45,8 @@ importance.
 
 - the `release_text` option does not work if the `--next-release` is specified
   and corresponds to that `release_text` version.
+- no validation on the URI input fields (hompage, repository) which could cause
+  Pooetry to fail to install the package.
 
 ## Back Burner
 

--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -312,7 +312,8 @@ See the [bold][green]README.md[/green][/bold] file for more information.
         # for PypI uploads.
         if not self.choices.standalone:
             self.choices.package_name = self.get_sanitized_package_name(pk_name)
-            self.choices.homepage = Prompt.ask("Homepage URL?", default="")
+
+        self.choices.homepage = Prompt.ask("Homepage URL?", default=None)
 
         # offer to create a repo on GitHub, for both type of projects.
         github_username = (

--- a/py_maker/template/pyproject.toml.jinja
+++ b/py_maker/template/pyproject.toml.jinja
@@ -8,9 +8,12 @@ license = "{{ license }}"
 
 {% if not standalone %}
 packages = [{ include = "{{ package_name }}" }]
-
+{% if homepage %}
 homepage = "{{ homepage }}"
+{%endif %}
+{% if repository %}
 repository = "{{ repository }}"
+{%endif %}
 
 [tool.poetry.urls]
 # customize the below URLs to point to your own GitHub repo. These will be


### PR DESCRIPTION
closes #317 

Also, do the same for the `repository` field. In addition, always ask for a homepage field, not only for non-standalone projects