### PR TITLE
Fix missing license name in generated README

### DIFF
--- a/py_maker/template/README.md.jinja
+++ b/py_maker/template/README.md.jinja
@@ -80,7 +80,7 @@ pre-commit installed at .git/hooks/pre-commit
 
 ## License
 
-This project is released under the terms of the {{ license }} license.
+This project is released under the terms of the {{ license_name }} license.
 
 ## Credits
 


### PR DESCRIPTION
The Jinja template was looking for the wrong variable name. Closes #321 