### PR TITLE
Fix some bugs in the template files and update obsolete information

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ When it asks "Package Name?" you can choose two variants :
    <http://pypi.org>, enter a package name here. Note that underscores ("_")
    must be used as opposed to dashes ("-") to comply with Python package naming
    rules.
-2. Enter '-' to instruct the tool that you are not creating any package, just a
-   standalone app, and then the `main.py` will just be placed in the project
-   root.
+2. Enter '-' (a dash) to instruct the tool that you are not creating any
+   package, just a standalone app, and then the `main.py` will just be placed in
+   the project root. The `pyproject.toml` file will not include any package
+   information and Poetry will never try to install or publish the package.
 
 You should now change into the new directory, install dependencies and activate
 the virtual environment:
@@ -108,8 +109,8 @@ Check the documentation at <https://py-maker.seapagan.net/> for more details.
 ### Task Runner
 
 The task-runner [Poe the Poet](https://github.com/nat-n/poethepoet) is installed
-as a development dependency which allows us to run simple tasks (similar to npm
-`scripts`).
+as a development dependency which allows us to run simple tasks (similar to
+`npm` scripts).
 
 These are run (from within the virtual environment) using the `poe` command and
 then the script name, for example:
@@ -118,15 +119,8 @@ then the script name, for example:
 $ poe pre
 ```
 
-You can define your own, but there are 6 specific ones provided with the script.
-
-- `pre` : Run `pre-commit run --all-files`
-- `ruff`: Run Ruff linter on all Python files in the project.
-- `format`: Run Ruff formatter on all Python files in the project.
-- `mypy`: Run MyPy type-checker on all Python files in the project.
-- `markdown`: Run pymarkdown on all markdown files in the project.
-
-- `lint`: Runs ruff, format, mypy, and markdown in sequence
+See the [Task Runner](https://py-maker.seapagan.net/tasks/) section in the
+documentation for more details and a list of available tasks.
 
 These are defined in the `pyproject.toml` file in the `[tool.poe.tasks]`
 section. Take a look at this file if you want to add or remove tasks.

--- a/py_maker/template/.pre-commit-config.yaml
+++ b/py_maker/template/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.0
+    rev: v0.3.2
     hooks:
       - id: ruff
       - id: ruff-format
@@ -25,7 +25,7 @@ repos:
         args: [-d, "MD046", scan]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.8.0"
+    rev: "v1.9.0"
     hooks:
       - id: mypy
         name: "run mypy"

--- a/py_maker/template/README.md.jinja
+++ b/py_maker/template/README.md.jinja
@@ -31,8 +31,8 @@ Now, you can start to code the meat of your application.
 ### Task Runner
 
 The task-runner [Poe the Poet](https://github.com/nat-n/poethepoet) is installed
-as a development dependency which allows us to run simple tasks (similar to npm
-`scripts`).
+as a development dependency which allows us to run simple tasks (similar to
+`npm` scripts).
 
 These are run (from within the virtual environment) using the `poe` command and
 then the script name, for example:
@@ -41,29 +41,19 @@ then the script name, for example:
 $ poe pre
 ```
 
-You can define your own, but there are 7 specific ones provided with the script.
-
-- `pre` : Run `pre-commit run --all-files`
-- `pylint`: Run Pylint on all Python files in the project.
-- `mypy` = Run MyPy type-checker on all Python files in the project.
-- `flake8` = Run Flake8 linter on all Python files in the project.
-- `black` = Run Black code formatter on all Python files in the project.
-- `try` = Run Tryceratops linter on all Python files in the project.
-
-- `lint` = Runs pylint, mypy, flake8 and black in sequence
+See the [Task Runner](https://py-maker.seapagan.net/tasks/) section in the
+documentation for more details and a list of available tasks.
 
 These are defined in the `pyproject.toml` file in the `[tool.poe.tasks]`
 section. Take a look at this file if you want to add or remove tasks.
 
 ### Linting
 
-This project includes [flake8](https://flake8.pycqa.org/en/latest/) (with
-several plugins) for linting and
-[Black](https://black.readthedocs.io/en/stable/) for formatting.
-[Mypy](http://mypy-lang.org/) is installed for type checking.
-[isort](https://pycqa.github.io/isort/),[Pylint](https://pylint.org/) and
-[tyrceratops](https://github.com/guilatrova/tryceratops) are also installed as
-standard.
+The generated project includes
+[Ruff](https://docs.astral.sh/ruff/){:target="_blank"} for linting and code
+style formatting. [Mypy](http://mypy-lang.org/){:target="_blank"} is installed
+for type checking. These are set quite strictly by default, but you can edit the
+tools configuration in the `pyproject.toml` file.
 
 ### Pre-commit
 

--- a/py_maker/template/pyproject.toml.jinja
+++ b/py_maker/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "{{ description }}."
 authors = ["{{ author }} <{{ email }}>"]
 readme = "README.md"
-license = "{{ license }}"
+license = "{{ license_name }}"
 
 {% if not standalone %}
 packages = [{ include = "{{ package_name }}" }]


### PR DESCRIPTION
- [x] The README for the generated project still mentions flake8, black, etc, in the `Task Runner` and `Linting` sections. These have all been replaced by `ruff`.
- [x] `.pre-commit-config.yaml` needs tool versions updating.
- [x] The license name is missing in the generated `pyproject.toml`