### PR TITLE
Ensure a second commit is created if the pre-commit is updated

### DIFF
--- a/py_maker/pymaker.py
+++ b/py_maker/pymaker.py
@@ -433,6 +433,15 @@ See the [bold][green]README.md[/green][/bold] file for more information.
                 ],
                 check=True,
             )
+
+            # check if we have modified the .pre-commit-config.yaml file
+            # and if so, create a new Git commit (if using git).
+            repo = Repo(self.choices.project_dir)
+            if repo.is_dirty():
+                repo.index.add(
+                    [str(self.choices.project_dir / ".pre-commit-config.yaml")]
+                )
+                repo.index.commit("Update pre-commit hooks")
         else:
             print(
                 """\n  [red]Warning: pre-commit hooks not installed or updated.


### PR DESCRIPTION
If the pre-commit config is updated during the generation stage, add the change as a second Git commit.

Note, doing it this way instead of creating the git repo after, since the `pre-commit` needs an existing Git repo to attach to.

Closes #386 