### PR TITLE
Lower dependabot check frequency in template to weekly

### DIFF
--- a/py_maker/template/.github/dependabot.yml
+++ b/py_maker/template/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
The template was set to check dependabot daily which ends up with a lot of PR noise. Changed it to weekly.